### PR TITLE
webhook fixed in docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,13 @@ FROM golang:1.24.2-bookworm
 RUN  	apt-get update && \
 	apt-get -y install git wget
 
-# installing satsmobi core
-RUN 	cd /opt && \
-	wget https://github.com/massmux/SatsMobiBot/archive/refs/tags/202504090700.tar.gz &&\
-	tar xzvf 202504090700.tar.gz &&\
-	mv SatsMobiBot-202504090700 SatsMobiBot
-
+COPY ./ /opt/SatsMobiBot/
 WORKDIR /opt/SatsMobiBot
-COPY ./go.mod /opt/SatsMobiBot/go.mod
 
 RUN	cd /opt/SatsMobiBot && go build .
+
+EXPOSE	5454
+EXPOSE	5588
+EXPOSE	6060
 
 CMD [ "./SatsMobiBot" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/massmux/SatsMobiBot
 
-go 1.18
+//go 1.18
+go 1.24.2
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/internal/api/lightning.go
+++ b/internal/api/lightning.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/massmux/SatsMobiBot/internal"
 	"github.com/massmux/SatsMobiBot/internal/lnbits"
 	"github.com/massmux/SatsMobiBot/internal/telegram"
-	"github.com/gorilla/mux"
 	"github.com/r3labs/sse"
 )
 
@@ -59,7 +59,7 @@ func (s Service) CreateInvoice(w http.ResponseWriter, r *http.Request) {
 			DescriptionHash:     createInvoiceRequest.DescriptionHash,
 			UnhashedDescription: createInvoiceRequest.UnhashedDescription,
 			Memo:                createInvoiceRequest.Memo,
-			Webhook:             internal.Configuration.Lnbits.WebhookServer},
+			Webhook:             internal.Configuration.Lnbits.WebhookCall},
 		s.Bot.Client)
 	if err != nil {
 		RespondError(w, "could not create invoice")

--- a/internal/config.go
+++ b/internal/config.go
@@ -83,6 +83,7 @@ type LnbitsConfiguration struct {
 	Url              string   `yaml:"url"`
 	LnbitsPublicUrl  string   `yaml:"lnbits_public_url"`
 	WebhookServer    string   `yaml:"webhook_server"`
+	WebhookCall      string   `yaml:"webhook_call"`
 	WebhookServerUrl *url.URL `yaml:"-"`
 }
 

--- a/internal/lnurl/lnurl.go
+++ b/internal/lnurl/lnurl.go
@@ -19,12 +19,12 @@ import (
 	"github.com/massmux/SatsMobiBot/internal/storage"
 	"gorm.io/gorm"
 
+	"github.com/fiatjaf/go-lnurl"
+	"github.com/gorilla/mux"
 	db "github.com/massmux/SatsMobiBot/internal/database"
 	"github.com/massmux/SatsMobiBot/internal/lnbits"
 	"github.com/massmux/SatsMobiBot/internal/runtime"
 	"github.com/massmux/SatsMobiBot/internal/telegram"
-	"github.com/fiatjaf/go-lnurl"
-	"github.com/gorilla/mux"
 	"github.com/nbd-wtf/go-nostr"
 	log "github.com/sirupsen/logrus"
 )
@@ -54,7 +54,7 @@ type Lnurl struct {
 	database         *gorm.DB
 	callbackHostname *url.URL
 	buntdb           *storage.DB
-	WebhookServer    string
+	WebhookCall      string
 	cache            telegram.Cache
 	bot              *telegram.TipBot
 }
@@ -64,11 +64,12 @@ func New(bot *telegram.TipBot) Lnurl {
 		c:                bot.Client,
 		database:         bot.DB.Users,
 		callbackHostname: internal.Configuration.Bot.LNURLHostUrl,
-		WebhookServer:    internal.Configuration.Lnbits.WebhookServer,
-		buntdb:           bot.Bunt,
-		telegram:         bot.Telegram,
-		cache:            bot.Cache,
-		bot:              bot,
+		//WebhookServer:    internal.Configuration.Lnbits.WebhookServer,
+		WebhookCall: internal.Configuration.Lnbits.WebhookCall,
+		buntdb:      bot.Bunt,
+		telegram:    bot.Telegram,
+		cache:       bot.Cache,
+		bot:         bot,
 	}
 }
 func (lnurlInvoice Invoice) Key() string {
@@ -362,7 +363,7 @@ func (w Lnurl) serveLNURLpSecond(username string, amount_msat int64, comment str
 			Amount:          amount_msat / 1000,
 			Out:             false,
 			DescriptionHash: descriptionHash,
-			Webhook:         w.WebhookServer},
+			Webhook:         w.WebhookCall},
 		w.c)
 	if err != nil {
 		err = fmt.Errorf("[serveLNURLpSecond] Couldn't create invoice: %v", err.Error())

--- a/internal/telegram/generate.go
+++ b/internal/telegram/generate.go
@@ -238,7 +238,7 @@ func (bot *TipBot) dalleRefundUser(user *lnbits.User, message string) error {
 			Out:     false,
 			Amount:  int64(internal.Configuration.Generate.DallePrice),
 			Memo:    fmt.Sprintf("Refund DALLE2 %s", GetUserStr(user.Telegram)),
-			Webhook: internal.Configuration.Lnbits.WebhookServer},
+			Webhook: internal.Configuration.Lnbits.WebhookCall},
 		bot.Client)
 	if err != nil {
 		return err

--- a/internal/telegram/groups.go
+++ b/internal/telegram/groups.go
@@ -381,7 +381,7 @@ func (bot *TipBot) groupGetInviteLinkHandler(event Event) {
 				Out:     false,
 				Amount:  commissionSat,
 				Memo:    "🎟 Ticket commission for group " + ticketEvent.Group.Title,
-				Webhook: internal.Configuration.Lnbits.WebhookServer},
+				Webhook: internal.Configuration.Lnbits.WebhookCall},
 			bot.Client)
 		if err != nil {
 			errmsg := fmt.Sprintf("[/invoice] Could not create an invoice: %s", err.Error())
@@ -585,7 +585,7 @@ func (bot *TipBot) createGroupTicketInvoice(ctx context.Context, payer *lnbits.U
 			Out:     false,
 			Amount:  group.Ticket.Price,
 			Memo:    memo,
-			Webhook: internal.Configuration.Lnbits.WebhookServer},
+			Webhook: internal.Configuration.Lnbits.WebhookCall},
 		bot.Client)
 	if err != nil {
 		errmsg := fmt.Sprintf("[/invoice] Could not create an invoice: %s", err.Error())

--- a/internal/telegram/invoice.go
+++ b/internal/telegram/invoice.go
@@ -188,7 +188,7 @@ func (bot *TipBot) createInvoiceWithEvent(ctx context.Context, user *lnbits.User
 			Out:     false,
 			Amount:  int64(amount),
 			Memo:    memo,
-			Webhook: internal.Configuration.Lnbits.WebhookServer},
+			Webhook: internal.Configuration.Lnbits.WebhookCall},
 		bot.Client)
 	if err != nil {
 		errmsg := fmt.Sprintf("[/invoice] Could not create an invoice: %s", err.Error())

--- a/internal/telegram/lnurl-withdraw.go
+++ b/internal/telegram/lnurl-withdraw.go
@@ -20,8 +20,8 @@ import (
 	"github.com/massmux/SatsMobiBot/internal/lnbits"
 	"github.com/massmux/SatsMobiBot/internal/runtime"
 
-	"github.com/massmux/SatsMobiBot/internal/str"
 	lnurl "github.com/fiatjaf/go-lnurl"
+	"github.com/massmux/SatsMobiBot/internal/str"
 	log "github.com/sirupsen/logrus"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
 )
@@ -263,7 +263,7 @@ func (bot *TipBot) confirmWithdrawHandler(ctx intercept.Context) (intercept.Cont
 			Out:     false,
 			Amount:  int64(lnurlWithdrawState.Amount) / 1000,
 			Memo:    "Withdraw",
-			Webhook: internal.Configuration.Lnbits.WebhookServer},
+			Webhook: internal.Configuration.Lnbits.WebhookCall},
 		bot.Client)
 	if err != nil {
 		errmsg := fmt.Sprintf("[lnurlWithdrawHandlerWithdraw] Could not create an invoice: %s", err.Error())

--- a/internal/telegram/ticket.go
+++ b/internal/telegram/ticket.go
@@ -59,7 +59,7 @@ func (bot *TipBot) handleTelegramNewMember(ctx intercept.Context) (intercept.Con
 			Out:     false,
 			Amount:  ticket.Ticket.Price,
 			Memo:    ticket.Ticket.Memo,
-			Webhook: internal.Configuration.Lnbits.WebhookServer},
+			Webhook: internal.Configuration.Lnbits.WebhookCall},
 		bot.Client)
 	if err != nil {
 		errmsg := fmt.Sprintf("[handleTelegramNewMember] Could not create an invoice: %s", err.Error())


### PR DESCRIPTION


- updated for go 1.24.2
- code fixed to support docker networking. Webhook has been fixed. Now Webhook server is separated from Webhook call. The whole system is therefore more flexible.